### PR TITLE
Allow using windows_exporter as package

### DIFF
--- a/collector/ad.go
+++ b/collector/ad.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	registerCollector("ad", NewADCollector)
+	registerCollector("ad", builderFunc(NewADCollector))
 }
 
 // A ADCollector is a Prometheus collector for WMI Win32_PerfRawData_DirectoryServices_DirectoryServices metrics

--- a/collector/adfs.go
+++ b/collector/adfs.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	registerCollector("adfs", newADFSCollector, "AD FS")
+	registerCollector("adfs", builderFunc(newADFSCollector), "AD FS")
 }
 
 type adfsCollector struct {

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -32,3 +32,16 @@ func TestExpandChildCollectors(t *testing.T) {
 		})
 	}
 }
+
+func TestNewCollectors(t *testing.T) {
+	var (
+		set1 = NewCollectors()
+		set2 = NewCollectors()
+
+		iis1 = set1.builders["iis"].(*IISCollectorConfig)
+		iis2 = set2.builders["iis"].(*IISCollectorConfig)
+	)
+	if iis1 == iis2 {
+		t.Errorf("collector config structs not copied")
+	}
+}

--- a/collector/container.go
+++ b/collector/container.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	registerCollector("container", NewContainerMetricsCollector)
+	registerCollector("container", builderFunc(NewContainerMetricsCollector))
 }
 
 // A ContainerMetricsCollector is a Prometheus collector for containers metrics

--- a/collector/cpu.go
+++ b/collector/cpu.go
@@ -16,7 +16,7 @@ func init() {
 	} else {
 		deps = "Processor"
 	}
-	registerCollector("cpu", newCPUCollector, deps)
+	registerCollector("cpu", builderFunc(newCPUCollector), deps)
 }
 
 type cpuCollectorBasic struct {

--- a/collector/cs.go
+++ b/collector/cs.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	registerCollector("cs", NewCSCollector)
+	registerCollector("cs", builderFunc(NewCSCollector))
 }
 
 // A CSCollector is a Prometheus collector for WMI metrics

--- a/collector/dfsr.go
+++ b/collector/dfsr.go
@@ -18,7 +18,7 @@ func init() {
 		perflibDependencies = append(perflibDependencies, dfsrGetPerfObjectName(source))
 	}
 
-	registerCollector("dfsr", NewDFSRCollector, perflibDependencies...)
+	registerCollector("dfsr", builderFunc(NewDFSRCollector), perflibDependencies...)
 }
 
 // DFSRCollector contains the metric and state data of the DFSR collectors.

--- a/collector/dhcp.go
+++ b/collector/dhcp.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	registerCollector("dhcp", NewDhcpCollector, "DHCP Server")
+	registerCollector("dhcp", builderFunc(NewDhcpCollector), "DHCP Server")
 }
 
 // A DhcpCollector is a Prometheus collector perflib DHCP metrics

--- a/collector/dns.go
+++ b/collector/dns.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	registerCollector("dns", NewDNSCollector)
+	registerCollector("dns", builderFunc(NewDNSCollector))
 }
 
 // A DNSCollector is a Prometheus collector for WMI Win32_PerfRawData_DNS_DNS metrics

--- a/collector/exchange.go
+++ b/collector/exchange.go
@@ -13,7 +13,7 @@ import (
 )
 
 func init() {
-	registerCollector("exchange", newExchangeCollector,
+	registerCollector("exchange", builderFunc(newExchangeCollector),
 		"MSExchange ADAccess Processes",
 		"MSExchangeTransport Queues",
 		"MSExchange HttpProxy",

--- a/collector/fsrmquota.go
+++ b/collector/fsrmquota.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	registerCollector("fsrmquota", newFSRMQuotaCollector)
+	registerCollector("fsrmquota", builderFunc(newFSRMQuotaCollector))
 }
 
 type FSRMQuotaCollector struct {

--- a/collector/hyperv.go
+++ b/collector/hyperv.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	registerCollector("hyperv", NewHyperVCollector)
+	registerCollector("hyperv", builderFunc(NewHyperVCollector))
 }
 
 // HyperVCollector is a Prometheus collector for hyper-v

--- a/collector/logical_disk.go
+++ b/collector/logical_disk.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	registerCollector("logical_disk", NewLogicalDiskCollector, "LogicalDisk")
+	registerCollector("logical_disk", builderFunc(NewLogicalDiskCollector), "LogicalDisk")
 }
 
 var (

--- a/collector/logon.go
+++ b/collector/logon.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	registerCollector("logon", NewLogonCollector)
+	registerCollector("logon", builderFunc(NewLogonCollector))
 }
 
 // A LogonCollector is a Prometheus collector for WMI metrics

--- a/collector/memory.go
+++ b/collector/memory.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	registerCollector("memory", NewMemoryCollector, "Memory")
+	registerCollector("memory", builderFunc(NewMemoryCollector), "Memory")
 }
 
 // A MemoryCollector is a Prometheus collector for perflib Memory metrics

--- a/collector/msmq.go
+++ b/collector/msmq.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	registerCollector("msmq", NewMSMQCollector)
+	registerCollector("msmq", builderFunc(NewMSMQCollector))
 }
 
 var (

--- a/collector/mssql.go
+++ b/collector/mssql.go
@@ -126,7 +126,7 @@ func mssqlGetPerfObjectName(sqlInstance string, collector string) string {
 }
 
 func init() {
-	registerCollector("mssql", NewMSSQLCollector)
+	registerCollector("mssql", builderFunc(NewMSSQLCollector))
 }
 
 // A MSSQLCollector is a Prometheus collector for various WMI Win32_PerfRawData_MSSQLSERVER_* metrics

--- a/collector/net.go
+++ b/collector/net.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	registerCollector("net", NewNetworkCollector, "Network Interface")
+	registerCollector("net", builderFunc(NewNetworkCollector), "Network Interface")
 }
 
 var (

--- a/collector/netframework_clrexceptions.go
+++ b/collector/netframework_clrexceptions.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	registerCollector("netframework_clrexceptions", NewNETFramework_NETCLRExceptionsCollector)
+	registerCollector("netframework_clrexceptions", builderFunc(NewNETFramework_NETCLRExceptionsCollector))
 }
 
 // A NETFramework_NETCLRExceptionsCollector is a Prometheus collector for WMI Win32_PerfRawData_NETFramework_NETCLRExceptions metrics

--- a/collector/netframework_clrinterop.go
+++ b/collector/netframework_clrinterop.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	registerCollector("netframework_clrinterop", NewNETFramework_NETCLRInteropCollector)
+	registerCollector("netframework_clrinterop", builderFunc(NewNETFramework_NETCLRInteropCollector))
 }
 
 // A NETFramework_NETCLRInteropCollector is a Prometheus collector for WMI Win32_PerfRawData_NETFramework_NETCLRInterop metrics

--- a/collector/netframework_clrjit.go
+++ b/collector/netframework_clrjit.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	registerCollector("netframework_clrjit", NewNETFramework_NETCLRJitCollector)
+	registerCollector("netframework_clrjit", builderFunc(NewNETFramework_NETCLRJitCollector))
 }
 
 // A NETFramework_NETCLRJitCollector is a Prometheus collector for WMI Win32_PerfRawData_NETFramework_NETCLRJit metrics

--- a/collector/netframework_clrloading.go
+++ b/collector/netframework_clrloading.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	registerCollector("netframework_clrloading", NewNETFramework_NETCLRLoadingCollector)
+	registerCollector("netframework_clrloading", builderFunc(NewNETFramework_NETCLRLoadingCollector))
 }
 
 // A NETFramework_NETCLRLoadingCollector is a Prometheus collector for WMI Win32_PerfRawData_NETFramework_NETCLRLoading metrics

--- a/collector/netframework_clrlocksandthreads.go
+++ b/collector/netframework_clrlocksandthreads.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	registerCollector("netframework_clrlocksandthreads", NewNETFramework_NETCLRLocksAndThreadsCollector)
+	registerCollector("netframework_clrlocksandthreads", builderFunc(NewNETFramework_NETCLRLocksAndThreadsCollector))
 }
 
 // A NETFramework_NETCLRLocksAndThreadsCollector is a Prometheus collector for WMI Win32_PerfRawData_NETFramework_NETCLRLocksAndThreads metrics

--- a/collector/netframework_clrmemory.go
+++ b/collector/netframework_clrmemory.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	registerCollector("netframework_clrmemory", NewNETFramework_NETCLRMemoryCollector)
+	registerCollector("netframework_clrmemory", builderFunc(NewNETFramework_NETCLRMemoryCollector))
 }
 
 // A NETFramework_NETCLRMemoryCollector is a Prometheus collector for WMI Win32_PerfRawData_NETFramework_NETCLRMemory metrics

--- a/collector/netframework_clrremoting.go
+++ b/collector/netframework_clrremoting.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	registerCollector("netframework_clrremoting", NewNETFramework_NETCLRRemotingCollector)
+	registerCollector("netframework_clrremoting", builderFunc(NewNETFramework_NETCLRRemotingCollector))
 }
 
 // A NETFramework_NETCLRRemotingCollector is a Prometheus collector for WMI Win32_PerfRawData_NETFramework_NETCLRRemoting metrics

--- a/collector/netframework_clrsecurity.go
+++ b/collector/netframework_clrsecurity.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	registerCollector("netframework_clrsecurity", NewNETFramework_NETCLRSecurityCollector)
+	registerCollector("netframework_clrsecurity", builderFunc(NewNETFramework_NETCLRSecurityCollector))
 }
 
 // A NETFramework_NETCLRSecurityCollector is a Prometheus collector for WMI Win32_PerfRawData_NETFramework_NETCLRSecurity metrics

--- a/collector/os.go
+++ b/collector/os.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	registerCollector("os", NewOSCollector)
+	registerCollector("os", builderFunc(NewOSCollector))
 }
 
 // A OSCollector is a Prometheus collector for WMI metrics

--- a/collector/process.go
+++ b/collector/process.go
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	registerCollector("process", newProcessCollector, "Process")
+	registerCollector("process", builderFunc(newProcessCollector), "Process")
 }
 
 var (

--- a/collector/remote_fx.go
+++ b/collector/remote_fx.go
@@ -10,7 +10,7 @@ import (
 )
 
 func init() {
-	registerCollector("remote_fx", NewRemoteFx, "RemoteFX Network", "RemoteFX Graphics")
+	registerCollector("remote_fx", builderFunc(NewRemoteFx), "RemoteFX Network", "RemoteFX Graphics")
 }
 
 // A RemoteFxNetworkCollector is a Prometheus collector for

--- a/collector/service.go
+++ b/collector/service.go
@@ -13,7 +13,7 @@ import (
 )
 
 func init() {
-	registerCollector("service", NewserviceCollector)
+	registerCollector("service", builderFunc(NewserviceCollector))
 }
 
 var (

--- a/collector/smtp.go
+++ b/collector/smtp.go
@@ -4,15 +4,16 @@ package collector
 
 import (
 	"fmt"
+	"regexp"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 	"gopkg.in/alecthomas/kingpin.v2"
-	"regexp"
 )
 
 func init() {
-	log.Info("smtp collector is in an experimental state! Metrics for this collector have not been tested.")
-	registerCollector("smtp", NewSMTPCollector, "SMTP Server")
+	log.Info("smtp collector is in an experimental state! Metrics for this collector have not been testedb.")
+	registerCollector("smtp", builderFunc(NewSMTPCollector), "SMTP Server")
 }
 
 var (

--- a/collector/system.go
+++ b/collector/system.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	registerCollector("system", NewSystemCollector, "System")
+	registerCollector("system", builderFunc(NewSystemCollector), "System")
 }
 
 // A SystemCollector is a Prometheus collector for WMI metrics

--- a/collector/tcp.go
+++ b/collector/tcp.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	registerCollector("tcp", NewTCPCollector, "TCPv4", "TCPv6")
+	registerCollector("tcp", builderFunc(NewTCPCollector), "TCPv4", "TCPv6")
 }
 
 // A TCPCollector is a Prometheus collector for WMI Win32_PerfRawData_Tcpip_TCPv{4,6} metrics

--- a/collector/terminal_services.go
+++ b/collector/terminal_services.go
@@ -14,7 +14,7 @@ import (
 const ConnectionBrokerFeatureID uint32 = 133
 
 func init() {
-	registerCollector("terminal_services", NewTerminalServicesCollector, "Terminal Services", "Terminal Services Session", "Remote Desktop Connection Broker Counterset")
+	registerCollector("terminal_services", builderFunc(NewTerminalServicesCollector), "Terminal Services", "Terminal Services Session", "Remote Desktop Connection Broker Counterset")
 }
 
 var (

--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -54,7 +54,7 @@ type textFileCollector struct {
 }
 
 func init() {
-	registerCollector("textfile", NewTextFileCollector)
+	registerCollector("textfile", builderFunc(NewTextFileCollector))
 }
 
 // NewTextFileCollector returns a new Collector exposing metrics read from files

--- a/collector/thermalzone.go
+++ b/collector/thermalzone.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	registerCollector("thermalzone", NewThermalZoneCollector)
+	registerCollector("thermalzone", builderFunc(NewThermalZoneCollector))
 }
 
 // A thermalZoneCollector is a Prometheus collector for WMI Win32_PerfRawData_Counters_ThermalZoneInformation metrics

--- a/collector/time.go
+++ b/collector/time.go
@@ -10,7 +10,7 @@ import (
 )
 
 func init() {
-	registerCollector("time", newTimeCollector, "Windows Time Service")
+	registerCollector("time", builderFunc(newTimeCollector), "Windows Time Service")
 }
 
 // TimeCollector is a Prometheus collector for Perflib counter metrics

--- a/collector/vmware.go
+++ b/collector/vmware.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	registerCollector("vmware", NewVmwareCollector)
+	registerCollector("vmware", builderFunc(NewVmwareCollector))
 }
 
 // A VmwareCollector is a Prometheus collector for WMI Win32_PerfRawData_vmGuestLib_VMem/Win32_PerfRawData_vmGuestLib_VCPU metrics

--- a/tools/collector-generator/collector.template
+++ b/tools/collector-generator/collector.template
@@ -5,7 +5,7 @@ import (
     "github.com/prometheus/common/log"
 )
 func init() {
-    registerCollector("{{ .CollectorName | toLower }}", new{{ .CollectorName }}Collector) // TODO: Add any perflib dependencies here
+    registerCollector("{{ .CollectorName | toLower }}", builderFunc(new{{ .CollectorName }}Collector)) // TODO: Add any perflib dependencies here
 }
 // A {{ .CollectorName }}Collector is a Prometheus collector for WMI {{ .Class }} metrics
 type {{ .CollectorName }}Collector struct {


### PR DESCRIPTION
This PR has the following changes:

1. Make `collectorBuilder` an interface 
2. Allow multiple sets of collector builders to be created
3. Use `iis` as the first example of a non-global configurable collector

TODO:

- [ ] Convert other globals to `*Config` structs
- [ ] Migrate as much logic as needed out of the main package